### PR TITLE
manually forming paths for etree consumption for Windows compatibility

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -47,10 +47,10 @@ module.exports = (function() {
         self.workbookPath = workbookPath;
         self.prefix       = path.dirname(workbookPath);
         self.workbook     = etree.parse(self.archive.file(workbookPath).asText()).getroot();
-        self.workbookRels = etree.parse(self.archive.file(path.join(self.prefix, '_rels', path.basename(workbookPath) + '.rels')).asText()).getroot();
+        self.workbookRels = etree.parse(self.archive.file(self.prefix + "/" + '_rels' + "/" + path.basename(workbookPath) + '.rels').asText()).getroot();
         self.sheets       = self.loadSheets(self.prefix, self.workbook, self.workbookRels);
 
-        self.sharedStringsPath = path.join(self.prefix, self.workbookRels.find("Relationship[@Type='" + SHARED_STRINGS_RELATIONSHIP + "']").attrib.Target);
+        self.sharedStringsPath = self.prefix + "/" + self.workbookRels.find("Relationship[@Type='" + SHARED_STRINGS_RELATIONSHIP + "']").attrib.Target;
         self.sharedStrings = [];
         etree.parse(self.archive.file(self.sharedStringsPath).asText()).getroot().findall('si/t').forEach(function(t) {
             self.sharedStrings.push(t.text);
@@ -261,7 +261,7 @@ module.exports = (function() {
             var sheetId      = sheet.attrib.sheetId,
                 relId        = sheet.attrib['r:id'],
                 relationship = workbookRels.find("Relationship[@Id='" + relId + "']"),
-                filename     = path.join(prefix, relationship.attrib.Target);
+                filename     = prefix + "/" + relationship.attrib.Target;
 
             sheets.push({
                 id: parseInt(sheetId, 10),
@@ -304,7 +304,7 @@ module.exports = (function() {
 
         var sheetDirectory = path.dirname(sheetFilename),
             sheetName      = path.basename(sheetFilename),
-            relsFilename   = path.join(sheetDirectory, '_rels', sheetName + '.rels'),
+            relsFilename   = sheetDirectory + "/" + '_rels' + "/" + sheetName + '.rels',
             relsFile       = self.archive.file(relsFilename),
             tables         = []; // [{filename: ..., root: ....}]
 
@@ -317,7 +317,7 @@ module.exports = (function() {
         sheet.findall("tableParts/tablePart").forEach(function(tablePart) {
             var relationshipId = tablePart.attrib['r:id'],
                 target         = rels.find("Relationship[@Id='" + relationshipId + "']").attrib.Target,
-                tableFilename  = path.join(sheetDirectory, target),
+                tableFilename  = sheetDirectory + "/" + target,
                 tableTree      = etree.parse(self.archive.file(tableFilename).asText());
 
             tables.push({


### PR DESCRIPTION
It seems like the etree library expects paths to be formed with forward
slashes (because why wouldn't it?). Unfortunately on Windows systems,
path.join uses backslashes, causing a lot of "cannot call asText() on
undefined" errors.

If you'd rather resolve this another way no hard feelings - As long as a fix for windows platforms eventually ends up in npm. This library is quite practical for generating xlsx files. Thanks!