### PR TITLE
Better date compatibility with Excel

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -76,7 +76,7 @@ module.exports = (function() {
         sheetData.findall("row").forEach(function(row) {
             row.attrib.r = currentRow = self.getCurrentRow(row, totalRowsInserted);
             rows.push(row);
-            
+
             var cells = [],
                 cellsInserted = 0,
                 newTableRows = [];
@@ -88,7 +88,7 @@ module.exports = (function() {
                 // If c[@t="s"] (string column), look up /c/v@text as integer in
                 // `this.sharedStrings`
                 if(cell.attrib.t === "s") {
-                    
+
                     // Look for a shared string that may contain placeholders
                     var cellValue   = cell.find("v"),
                         stringIndex = parseInt(cellValue.text, 10),
@@ -141,7 +141,7 @@ module.exports = (function() {
                 if(appendCell) {
                     cells.push(cell);
                 }
-                
+
             }); // cells loop
 
             // We may have inserted columns, so re-build the children of the row
@@ -151,7 +151,7 @@ module.exports = (function() {
             if(cellsInserted !== 0) {
                 self.updateRowSpan(row, cellsInserted);
             }
-            
+
             // Add newly inserted rows
             if(newTableRows.length > 0) {
                 newTableRows.forEach(function(row) {
@@ -160,7 +160,7 @@ module.exports = (function() {
                 });
                 self.pushDown(self.workbook, sheet.root, namedTables, currentRow, newTableRows.length);
             }
-            
+
         }); // rows loop
 
         // We may have inserted rows, so re-build the children of the sheetData
@@ -194,7 +194,7 @@ module.exports = (function() {
 
         var root = etree.parse(self.archive.file(self.sharedStringsPath).asText()).getroot(),
             children = root.getchildren();
-        
+
         root.delSlice(0, children.length);
 
         self.sharedStrings.forEach(function(string) {
@@ -254,7 +254,7 @@ module.exports = (function() {
     // Get a list of sheet ids, names and filenames
     Workbook.prototype.loadSheets = function(prefix, workbook, workbookRels) {
         var self = this;
-        
+
         var sheets = [];
 
         workbook.findall("sheets/sheet").forEach(function(sheet) {
@@ -399,7 +399,7 @@ module.exports = (function() {
 
         });
     };
-    
+
     // Return a list of tokens that may exist in the string.
     // Keys are: `placeholder` (the full placeholder, including the `${}`
     // delineators), `name` (the name part of the token), `key` (the object key
@@ -408,7 +408,7 @@ module.exports = (function() {
     Workbook.prototype.extractPlaceholders = function(string) {
         // Yes, that's right. It's a bunch of brackets and question marks and stuff.
         var re = /\${(?:(.+?):)?(.+?)(?:\.(.+?))?}/g;
-        
+
         var match = null, matches = [];
         while((match = re.exec(string)) !== null) {
             matches.push({
@@ -524,7 +524,11 @@ module.exports = (function() {
         var self = this;
 
         if(value instanceof Date) {
-            return value.toISOString();
+            //In Excel date is a number of days since 01/01/1900
+            //           timestamp in ms    to days      + number of days from 1900 to 1970
+            return Number(value.getTime()/(1000*60*60*24))+25569 + 1); //+ 1 day because:
+            // Excel incorrectly regards 1900 as a leap year and allows February 29 to be entered as a date in this year.
+            // This is for compatibility with Lotus 1-2-3 which also had this bug
         } else if(typeof(value) === "number" || typeof(value) === "boolean") {
             return Number(value).toString();
         } else {
@@ -581,11 +585,11 @@ module.exports = (function() {
 
         var newCellsInserted = -1, // we technically delete one before we start adding back
             currentCell = cell.attrib.r;
-                                
+
         // add a cell for each element in the list
         substitution.forEach(function(element) {
             ++newCellsInserted;
-            
+
             if(newCellsInserted > 0) {
                 currentCell = self.nextCol(currentCell);
             }
@@ -624,7 +628,7 @@ module.exports = (function() {
                     value = element[key];
 
                 if(idx === 0) { // insert in the row where the placeholders are
-                    
+
                     if(value instanceof Array) {
                         newCellsInserted = self.substituteArray(cells, cell, value);
                     } else {
@@ -632,7 +636,7 @@ module.exports = (function() {
                     }
 
                 } else { // insert new rows (or reuse rows just inserted)
-                    
+
                     // Do we have an existing row to use? If not, create one.
                     if((idx - 1) < newTableRows.length) {
                         newRow = newTableRows[idx - 1];
@@ -651,7 +655,7 @@ module.exports = (function() {
 
                     if(value instanceof Array) {
                         newCellsInsertedOnNewRow = self.substituteArray(newCells, newCell, value);
-                        
+
                         // Add each of the new cells created by substituteArray()
                         newCells.forEach(function(newCell) {
                             newRow.append(newCell);
@@ -670,7 +674,7 @@ module.exports = (function() {
                         var tableRoot = namedTable.root,
                             autoFilter = tableRoot.find("autoFilter"),
                             range = self.splitRange(tableRoot.attrib.ref);
-                        
+
                         if(!self.isWithin(newCell.attrib.r, range.start, range.end)) {
                             range.end = self.nextRow(range.end);
                             tableRoot.attrib.ref = self.joinRange(range);

--- a/lib/index.js
+++ b/lib/index.js
@@ -526,7 +526,7 @@ module.exports = (function() {
         if(value instanceof Date) {
             //In Excel date is a number of days since 01/01/1900
             //           timestamp in ms    to days      + number of days from 1900 to 1970
-            return Number(value.getTime()/(1000*60*60*24))+25569 + 1); //+ 1 day because:
+            return Number( (value.getTime()/(1000*60*60*24)) + 25569 + 1); //+ 1 day because:
             // Excel incorrectly regards 1900 as a leap year and allows February 29 to be entered as a date in this year.
             // This is for compatibility with Lotus 1-2-3 which also had this bug
         } else if(typeof(value) === "number" || typeof(value) === "boolean") {


### PR DESCRIPTION
I had issues with the ISO date format. 

My solution is to transform the date to an actual Excel date. It's the number of days since 01/01/1900:

```
 //In Excel date is a number of days since 01/01/1900
 //           timestamp in ms    to days      + number of days from 1900 to 1970
 return Number(value.getTime()/(1000*60*60*24))+25569 + 1); //+ 1 day because:
 // Excel incorrectly regards 1900 as a leap year and allows February 29 to be entered as a date in this year.
 // This is for compatibility with Lotus 1-2-3 which also had this bug
```

Sorry that my IDE removed unnecessary blank lines.