### PR TITLE
Fix issue where match is null

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -541,11 +541,11 @@ module.exports = (function() {
     Workbook.prototype.splitRef = function(ref) {
         var match = ref.match(/(?:(.+)!)?(\$)?([A-Z]+)(\$)?([0-9]+)/);
         return {
-            table: match[1] || null,
-            colAbsolute: Boolean(match[2]),
-            col: match[3],
-            rowAbsolute: Boolean(match[4]),
-            row: parseInt(match[5], 10)
+            table: match && match[1] || null,
+            colAbsolute: Boolean(match && match[2]),
+            col: match && match[3],
+            rowAbsolute: Boolean(match && match[4]),
+            row: parseInt(match && match[5], 10)
         };
     };
 


### PR DESCRIPTION
Apparently, match can be null, which caused the following error. Checking for nullness fixes the problem

```
C:\Users\sd\Documents\ExcelTemplating\node_modules\xlsx-template\lib\index.js:544
            table: match[1] || null,
                        ^

TypeError: Cannot read property '1' of null
    at Workbook.module.exports.Workbook.splitRef (C:\Users\sd\Documents\ExcelTemplating\node_modules\xlsx-template\lib\index.js:544:25)
    at C:\Users\sd\Documents\ExcelTemplating\node_modules\xlsx-template\lib\index.js:1000:37
    at Array.forEach (native)
    at Workbook.module.exports.Workbook.pushDown (C:\Users\sd\Documents\ExcelTemplating\node_modules\xlsx-template\lib\index.js:981:54)
    at C:\Users\sd\Documents\ExcelTemplating\node_modules\xlsx-template\lib\index.js:231:22
    at Array.forEach (native)
    at Workbook.module.exports.Workbook.substitute (C:\Users\sd\Documents\ExcelTemplating\node_modules\xlsx-template\lib\index.js:133:34)
    at C:\Users\sd\Documents\ExcelTemplating\excelTemplating2.js:25:11
    at FSReqWrap.readFileAfterClose [as oncomplete] (fs.js:445:3)
```

the problem happened when adding a formula as in this template: [template.xlsx](https://github.com/optilude/xlsx-template/files/771019/template.xlsx)
