### PR TITLE
Fix recalculation of formulas

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -146,7 +146,7 @@ module.exports = (function() {
                 var formulas = cell.findall('f');
                 if (formulas && formulas.length > 0) {
                   cell.findall('v').forEach(function(v){
-                    cell.remove(0,v);
+                    cell.remove(v);
                   });
                 }
 


### PR DESCRIPTION
Excel seems to recalculate a formula when the value of the cell is removed. However, I guess there's a typo in the source code, and the call to the remove function isn't correct.

Removing the `0` argument from the call seems to actually remove the value and recalculate the cell.