### PR TITLE
Use 'jszip' module instead of 'node-zip'

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -4,7 +4,7 @@
 "use strict";
 
 var path  = require('path'),
-    zip   = require('node-zip'),
+    zip   = require('jszip'),
     etree = require('elementtree');
 
 module.exports = (function() {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   ],
   "dependencies": {
     "elementtree": "0.1.6",
-    "node-zip": "1.1.1"
+    "jszip": "^2.6.1"
   },
   "devDependencies": {
     "buster": "0.7.18",


### PR DESCRIPTION
Use 'jszip' module instead of 'node-zip', since `node-zip` is just a `jszip`'s wrapper. (`node-zip` requires `fs` which cause an error with webpack)
https://github.com/daraosn/node-zip/blob/master/lib/nodezip.js