### PR TITLE
Remove support for NodeJS 0.12/Node 4.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: node_js
 node_js:
-  - 0.12
   - 6
   - 8


### PR DESCRIPTION
Seems to be that it not that much used now, and relatively soon should be moved out of maintainace mode.
I wuld be very glad to remove support for Node JS 0.12 and NodeJS 4 since this allow me use more modern JS without resorting to Babel.