### PR TITLE
workbookRels get wrong id

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -117,8 +117,10 @@ module.exports = (function() {
       .sort(function(rel1, rel2){ //using order
         var index1 = order.indexOf( path.basename(rel1.attrib.Type) ); 
         var index2 = order.indexOf( path.basename(rel2.attrib.Type) ); 
-        if ((index1 + index2) == 0) 
+        if ((index1 + index2) == 0) {
+            if(rel1.attrib.Id && rel2.attrib.Id) return rel1.attrib.Id.substring(3) - rel2.attrib.Id.substring(3);
           return rel1._id - rel2._id;
+        }
         return index1 - index2
       })
       .forEach(function(item, index) {


### PR DESCRIPTION
workbookRels has two id: _id, attrib.Id.

In the _rebuild, workbookRels would be sorted by _id.
but it is reset attrib.Id, that would be get wrong sheet.

this bug happen when the sort of _id is reverse sort of attrib.Id.

So I change sort method. Let it sort by attrib.Id.