### PR TITLE
fix wrongly replacing text in shared strings

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -770,8 +770,7 @@ module.exports = (function() {
         } else {
             var newString = string.replace(placeholder.placeholder, self.stringify(substitution));
             cell.attrib.t = "s";
-            self.replaceString(string, newString);
-            return newString;
+            return self.insertCellValue(cell, newString)
         }
 
     };

--- a/test/helpers-test.js
+++ b/test/helpers-test.js
@@ -638,8 +638,8 @@ describe("Helpers", function() {
             t.addSharedString(string);
             buster.expect(t.substituteScalar(col, string, placeholder, substitution)).toEqual("foo: bar");
             buster.expect(col.attrib.t).toEqual("s");
-            buster.expect(val.text).toEqual("0");
-            buster.expect(t.sharedStrings).toEqual(["foo: bar"]);
+            buster.expect(val.text).toEqual("1");
+            buster.expect(t.sharedStrings).toEqual(["foo: ${foo}", "foo: bar"]);
         });
 
         it("can substitute parts of strings with booleans", function() {
@@ -666,8 +666,8 @@ describe("Helpers", function() {
             t.addSharedString(string);
             buster.expect(t.substituteScalar(col, string, placeholder, substitution)).toEqual("foo: 0");
             buster.expect(col.attrib.t).toEqual("s");
-            buster.expect(val.text).toEqual("0");
-            buster.expect(t.sharedStrings).toEqual(["foo: 0"]);
+            buster.expect(val.text).toEqual("1");
+            buster.expect(t.sharedStrings).toEqual(["foo: ${foo}", "foo: 0"]);
         });
 
         it("can substitute parts of strings with numbers", function() {
@@ -694,8 +694,8 @@ describe("Helpers", function() {
             t.addSharedString(string);
             buster.expect(t.substituteScalar(col, string, placeholder, substitution)).toEqual("foo: 10");
             buster.expect(col.attrib.t).toEqual("s");
-            buster.expect(val.text).toEqual("0");
-            buster.expect(t.sharedStrings).toEqual(["foo: 10"]);
+            buster.expect(val.text).toEqual("1");
+            buster.expect(t.sharedStrings).toEqual(["foo: ${foo}", "foo: 10"]);
         });
 
 


### PR DESCRIPTION
This solves a similar problem as this pull request #69. Except this time it happens when there is only parts of strings that are substituted. For example, if you got something like "Page ${page}" in every sheet, in the output every "${page}" will have the same value.