### PR TITLE
Publish only lib folder in npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "version": "0.5.0",
   "description": "Generate .xlsx (Excel) files from templates built in Excel",
   "main": "./lib/index",
+  "files": [
+    "lib"
+  ],
   "author": {
     "name": "Martin Aspeli"
   },


### PR DESCRIPTION
A bunch of configs and test folder are not necessary in npm and only
increase node_modules size. In this diff I added "files" field which
includes only lib folder. Readme and license are included
unconditionally.