### PR TITLE
Remove testing on NodeJS which reach EOL

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,5 @@
 language: node_js
 node_js:
-  - 6
-  - 8
   - 10
   - 12
   - 14


### PR DESCRIPTION
This does not mean it would not work on these version, as I hardly imaging which we will use something special