### PR TITLE
first try simple pattern |a.b|

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -109,7 +109,7 @@ module.exports = (function() {
       newRel.attrib.Target = fileName;
 
       self._rebuild();
-//    TODO: work with "definedNames" 
+//    TODO: work with "definedNames"
 //    var defn = etree.SubElement(self.workbook.find('definedNames'), 'definedName');
 //
       return self
@@ -217,7 +217,7 @@ module.exports = (function() {
             rows = [],
             drawing = null;
 
-        var rels = self.loadSheetRels(sheet.filename);			   
+        var rels = self.loadSheetRels(sheet.filename);
         sheetData.findall("row").forEach(function(row) {
             row.attrib.r = currentRow = self.getCurrentRow(row, totalRowsInserted);
             rows.push(row);
@@ -341,7 +341,7 @@ module.exports = (function() {
                     if(drawing != null){
                         self.moveAllImages(drawing, row.attrib.r, newTableRows.length)
                     }
-                }				
+                }
                 newTableRows.forEach(function(row) {
                     rows.push(row);
                     ++totalRowsInserted;
@@ -401,7 +401,7 @@ module.exports = (function() {
 
         self.writeSharedStrings();
         self.writeTables(namedTables);
-        self.writeDrawing(drawing);																
+        self.writeDrawing(drawing);
     };
 
     /**
@@ -547,7 +547,7 @@ module.exports = (function() {
         var rels = {filename: relsFilename, root: etree.parse(relsFile.asText()).getroot()}
         return rels;
     }
-    
+
     Workbook.prototype.initSheetRels = function (sheetFilename) {
         var sheetDirectory = path.dirname(sheetFilename),
             sheetName = path.basename(sheetFilename),
@@ -568,7 +568,7 @@ module.exports = (function() {
             drawing = {filename: '', root: null};
         var drawingPart = sheet.find("drawing");
         if (drawingPart === null) {
-            drawing = self.initDrawing(sheet, rels);										
+            drawing = self.initDrawing(sheet, rels);
             return drawing;
         }
         var relationshipId = drawingPart.attrib['r:id'],
@@ -581,12 +581,12 @@ module.exports = (function() {
         drawing.relRoot = etree.parse(self.archive.file(drawing.relFilename).asText()).getroot();
         return drawing;
     };
-    
+
     Workbook.prototype.addContentType = function(partName, contentType){
         var self = this;
-        etree.SubElement(self.contentTypes, 'Override', { 'ContentType':contentType, 'PartName':partName});																		
+        etree.SubElement(self.contentTypes, 'Override', { 'ContentType':contentType, 'PartName':partName});
     }
-                                        
+
     Workbook.prototype.initDrawing = function (sheet, rels) {
         var self = this;
         var maxId = self.findMaxId(rels, 'Relationship', 'Id', /rId(\d*)/);
@@ -627,7 +627,7 @@ module.exports = (function() {
             //TODO : make the other tags image
         })
     };
-    
+
     //Move TwoCellAnchor tag images after fromRow of nbRow row
     Workbook.prototype._moveTwoCellAnchor = function(drawingElement, fromRow, nbRow){
         var self = this;
@@ -646,8 +646,8 @@ module.exports = (function() {
                 _moveImage(drawingElement, fromRow, nbRow)
             }
         }
-    };																	
-    
+    };
+
 
     // Load tables for a given sheet
     Workbook.prototype.loadTables = function(sheet, sheetFilename) {
@@ -809,6 +809,20 @@ module.exports = (function() {
     // for `table` tokens), `full` (boolean indicating whether this placeholder
     // is the entirety of the string) and `type` (one of `table` or `cell`)
     Workbook.prototype.extractPlaceholders = function(string) {
+        // first try simple pattern |a.b|
+        var table_re = /^\|([^.\s]+)\.([^.\s]+)\|$/
+        var table_match = table_re.exec(string)
+        if (table_match) {
+          return [
+              {
+                placeholder: table_match[0],
+                type: 'table',
+                name: table_match[1],
+                key: table_match[2],
+                full: true
+              }
+          ]
+        }
         // Yes, that's right. It's a bunch of brackets and question marks and stuff.
         var re = /\${(?:(.+?):)?(.+?)(?:\.(.+?))?(?::(.+?))??}/g;
 
@@ -1112,7 +1126,7 @@ module.exports = (function() {
         var rel = etree.SubElement(drawing.relRoot, 'Relationship');
         rel.set('Id', 'rId' + maxId);
         rel.set('Type', 'http://schemas.openxmlformats.org/officeDocument/2006/relationships/image');
-        
+
         rel.set('Target', '../media/image' + maxFildId + '.jpg');
         function toArrayBuffer(buffer) {
             var ab = new ArrayBuffer(buffer.length);
@@ -1430,7 +1444,7 @@ module.exports = (function() {
     Workbook.prototype.getWidthCell = function(numCol, sheet){
         var defaultWidth = sheet.root.find("sheetFormatPr").attrib["defaultColWidth"]
         if(!defaultWidth){
-            //TODO : Check why defaultColWidth is not set ? 
+            //TODO : Check why defaultColWidth is not set ?
             defaultWidth = 11.42578125
         }
         var finalWidth = defaultWidth;
@@ -1492,7 +1506,7 @@ module.exports = (function() {
 
     Workbook.prototype.columnWidthToEMUs = function (width) {
         // TODO : This is not the true. Change with true calcul
-        // can find help here : 
+        // can find help here :
         // https://docs.microsoft.com/en-us/office/troubleshoot/excel/determine-column-widths
         // https://stackoverflow.com/questions/58021996/how-to-set-the-fixed-column-width-values-in-inches-apache-poi
         // https://poi.apache.org/apidocs/dev/org/apache/poi/ss/usermodel/Sheet.html#setColumnWidth-int-int-
@@ -1594,7 +1608,7 @@ module.exports = (function() {
             }
         }
     }
-    
+
     Workbook.prototype.findMaxId = function (element, tag, attr, idRegex) {
         var maxId = 0;
         element.findall(tag).forEach((element)=> {


### PR DESCRIPTION
There are cases that render with multiple tables with many columns into one xlsx file. We need a more compact syntax for good template maintenance. compare `|t1.c1|` with `${table:t1.c1}`. This compact syntax should take priority of `${}` because rendering with tables should be the most use cases. 
