### PR TITLE
Fix merge cells style problem when using table substitution

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1076,6 +1076,8 @@ module.exports = (function() {
         var self = this,
             newCellsInserted = 0; // on the original row
 
+        const mergeCell = self.sheet.root.findall("mergeCells/mergeCell").find(c => self.splitRange(c.attrib.ref).start === cell.attrib.r)
+
         // if no elements, blank the cell, but don't delete it
         if(substitution.length === 0) {
             delete cell.attrib.t;
@@ -1137,6 +1139,23 @@ module.exports = (function() {
 
                         // Add the cell that previously held the placeholder
                         newRow.append(newCell);
+
+                        if(mergeCell) {
+                            var mergeRange    = self.splitRange(mergeCell.attrib.ref),
+                            mergeStart    = self.splitRef(mergeRange.start),
+                            mergeEnd      = self.splitRef(mergeRange.end);
+                            for (let colNum = self.charToNum(mergeStart.col) + 1; colNum <= self.charToNum(mergeEnd.col); colNum++) {
+                                const lastRow = self.sheet.root.find('sheetData').getItem(mergeStart.row - 1)
+                                const upperCell = lastRow.getItem(colNum - 1)
+                            
+                                const cell = self.cloneElement(upperCell);
+                                cell.attrib.r = self.joinRef({
+                                  row: newRow.attrib.r,
+                                  col: self.numToChar(colNum)
+                                });
+                                newRow.append(cell);
+                            }
+                        }
                     }
 
                     // expand named table range if necessary


### PR DESCRIPTION
### Reproduce The Error

1. Use table substitution, put the placeholder in a merge cells (B9:C9)
2. Generate the output
3. You can see the range C10:C23 border lines doesn't applied

Template
![image](https://user-images.githubusercontent.com/51365494/201066578-24f0d269-2738-4871-a94d-304f4efcafed.png)

Output
![image](https://user-images.githubusercontent.com/51365494/201066792-938baf3e-5035-420d-9ccb-be387bb3af01.png)



### Resolution
In source code Workbook.prototype.substituteTable function

First declare a mergeCell variable represent the current cell equals to the start cell of some mergeCells
``` const mergeCell = self.sheet.root.findall("mergeCells/mergeCell").find(c => self.splitRange(c.attrib.ref).start === cell.attrib.r)```


Second, if current cell is the start cell, copy the original merge cells, then for loop to append the last of cells in mergeRange
```
if(mergeCell) {
  var mergeRange    = self.splitRange(mergeCell.attrib.ref),
  mergeStart    = self.splitRef(mergeRange.start),
  mergeEnd      = self.splitRef(mergeRange.end);
  for (let colNum = self.charToNum(mergeStart.col) + 1; colNum <= self.charToNum(mergeEnd.col); colNum++) {
      const lastRow = self.sheet.root.find('sheetData').getItem(mergeStart.row - 1)
      const upperCell = lastRow.getItem(colNum - 1)
  
      const cell = self.cloneElement(upperCell);
      cell.attrib.r = self.joinRef({
        row: newRow.attrib.r,
        col: self.numToChar(colNum)
      });
      newRow.append(cell);
  }
}
```